### PR TITLE
Add missing packaging dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pyarrow>=0.15.0",
     "tqdm>=4.60.0,<5",
     "pydantic>=2.0.0,<3",
+    "packaging>=20.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary
- Add `packaging>=20.0` to dependencies in `pyproject.toml`

This fixes a `ModuleNotFoundError: No module named 'packaging'` that occurs when importing `arize.pandas.logger`, which uses `from packaging.version import parse as parse_version`.

## Test plan
- [x] Verify import works: `from arize.pandas.logger import Client`

Closes #109