### PR TITLE
fix: Fix ValueError when passing evals_dataframe to spans.log()

### DIFF
--- a/src/arize/spans/client.py
+++ b/src/arize/spans/client.py
@@ -143,7 +143,7 @@ class SpansClient:
         # We expect the index to be 0,1,2,3..., len(df)-1. Phoenix, for example, will give us a dataframe
         # with context_id as the index
         reset_dataframe_index(dataframe=spans_df)
-        if evals_df:
+        if evals_df is not None:
             reset_dataframe_index(dataframe=evals_df)
 
         log.debug("Performing direct input type validation")
@@ -183,7 +183,7 @@ class SpansClient:
             df=spans_df,
             column_list=[col.name for col in SPAN_OPENINFERENCE_COLUMNS],
         )
-        if evals_df:
+        if evals_df is not None:
             evals_df = remove_extraneous_columns(
                 df=evals_df,
                 column_list=[SPAN_SPAN_ID_COL.name],
@@ -199,7 +199,7 @@ class SpansClient:
                 spans_dataframe=spans_df,
                 project_name=project_name,
             )
-            if evals_df:
+            if evals_df is not None:
                 eval_errors = evals_validation.validate_values(
                     evals_dataframe=evals_df,
                     project_name=project_name,
@@ -224,7 +224,7 @@ class SpansClient:
 
         df = (
             pd.merge(spans_df, evals_df, on=SPAN_SPAN_ID_COL.name, how="left")
-            if evals_df
+            if evals_df is not None
             else spans_df
         )
 


### PR DESCRIPTION
 ## Summary

  Fix ValueError when passing evals_dataframe to spans.log()

  ## Problem

  When calling `spans.log()` with both a dataframe and an evals_dataframe, the method
  would fail with:
  ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(),
  a.item(), a.any() or a.all().

  This occurred because the code was using `if evals_df:` to check if the eval
  dataframe exists, but pandas DataFrames cannot be evaluated directly in a boolean
  context.

  ## Solution

  Changed all boolean checks on `evals_df` from `if evals_df:` to `if evals_df is not
  None:` to properly check for the existence of the dataframe.

  ## Changes

  Fixed 4 instances in `src/arize/spans/client.py`:
  - Line 146: Index reset check
  - Line 186: Column removal check
  - Line 202: Values validation check
  - Line 227: DataFrame merge check

  The code already used the correct pattern (`is not None`) in some places but was
  inconsistent.
