### PR TITLE
making prompt version actually optional

### DIFF
--- a/src/arize/_generated/api_client/models/prompt_with_version.py
+++ b/src/arize/_generated/api_client/models/prompt_with_version.py
@@ -35,7 +35,7 @@ class PromptWithVersion(BaseModel):
     created_at: datetime = Field(description="When the prompt was created")
     updated_at: datetime = Field(description="When the prompt was last updated")
     created_by_user_id: StrictStr = Field(description="The user ID of the user who created the prompt")
-    version: PromptVersion
+    version: Optional[PromptVersion] = None
     __properties: ClassVar[List[str]] = ["id", "name", "description", "space_id", "created_at", "updated_at", "created_by_user_id", "version"]
 
     model_config = ConfigDict(


### PR DESCRIPTION
Prompt version is supposed to be optional but its not actually set as optional in the BaseModel. Caused error when trying to return older prompts